### PR TITLE
As a user I should be able to view all announcements

### DIFF
--- a/Server/src/controllers/announcementController.js
+++ b/Server/src/controllers/announcementController.js
@@ -130,6 +130,32 @@ const controller={
                 "data":result
             });
         }
+    },
+    viewAnnouncements(req,res){
+        const token={
+            id:req.tokenId,
+            email:req.tokenEmail,
+            is_admin:req.tokenIs_admin
+        }; 
+        const results=AnnouncementModel.viewAnnouncements(token);
+        if(results=="no announcements"){
+            return res.status(403).json({
+                "status":"error",
+                "error":"Announcement does not exist"
+            });
+        }
+        else if(results=="not a user"){
+            return res.status(403).json({
+                "status":"error",
+                "error":"you are not a user"
+            });
+        }
+        else{
+            return res.status(200).json({
+                "status":"success",
+                "data":results
+            });
+        }
     }
 
 }

--- a/Server/src/models/announcement.js
+++ b/Server/src/models/announcement.js
@@ -109,5 +109,18 @@ class Announcement{
     else{
         return "not a user";
     }
-}}
+}
+viewAnnouncements(token){
+    const user= users.find((us)=>us.id==token.id);
+    if(user){
+        if(announcements){
+            return announcements;
+        }else{
+            return "no announcements";
+        }
+    }else{
+        return "not a user";
+    }
+}
+}
 export default new Announcement();

--- a/Server/src/routes/announcementRoutes.js
+++ b/Server/src/routes/announcementRoutes.js
@@ -9,6 +9,6 @@ router.post('/',authenticate,validateInput(schemas.announceSchema),controller.cr
 router.patch('/:id/sold',authenticate,validateInput(schemas.updateAnnounce),controller.updateStatus);
 router.patch('/:id',authenticate,validateInput(schemas.updateAnnounce),controller.updateAnnouncement);
 router.delete('/:id',authenticate,controller.deleteAnnouncement);
-
+router.get('/announcements',authenticate,controller.viewAnnouncements);
 
 export const announceRouter=router;


### PR DESCRIPTION
#### Description
Any user can view all created announcements
#### Type of change
Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [ ] Unit
- [ ] Integration
- [X] End-to-end
#### How to Test
you have to use this route
/api/v1/announcement/announcements
#### Pivotal Tracker
[Finishes #170816646]