### PR TITLE
As a user I should be able  to view a specific announcement's details

### DIFF
--- a/Server/src/controllers/announcementController.js
+++ b/Server/src/controllers/announcementController.js
@@ -156,6 +156,31 @@ const controller={
                 "data":results
             });
         }
+    },
+    announcementDetails(req,res){
+        const token={
+            id:req.tokenId,
+            email:req.tokenEmail,
+            is_admin:req.tokenIs_admin
+        }
+        const result=AnnouncementModel.announcementDetails(req.params.id,token);
+        if(result=="not a user"){
+            res.status(403).json({
+                "status":"error",
+                "error":"you are not a user"
+            });
+        }
+        else if(result=="not found"){
+            res.status(403).json({
+                "status":"error",
+                "error":"Announcement does not exists"
+            });
+        }else{
+            return res.status(200).json({
+                "status":"success",
+                "data":result
+            });  
+        }
     }
 
 }

--- a/Server/src/models/announcement.js
+++ b/Server/src/models/announcement.js
@@ -122,5 +122,18 @@ viewAnnouncements(token){
         return "not a user";
     }
 }
+announcementDetails(id,token){
+    const user=users.find((us)=>us.id==token.id);
+    if(user){
+        const announcement=announcements.find((announce)=>announce.id==id);
+        if(announcement){
+            return announcement;
+        }else{
+            return "not found";
+        }
+    }else{
+        return "not a user";
+    }
+}
 }
 export default new Announcement();

--- a/Server/src/routes/announcementRoutes.js
+++ b/Server/src/routes/announcementRoutes.js
@@ -10,5 +10,6 @@ router.patch('/:id/sold',authenticate,validateInput(schemas.updateAnnounce),cont
 router.patch('/:id',authenticate,validateInput(schemas.updateAnnounce),controller.updateAnnouncement);
 router.delete('/:id',authenticate,controller.deleteAnnouncement);
 router.get('/announcements',authenticate,controller.viewAnnouncements);
+router.get('/:id',authenticate,controller.announcementDetails);
 
 export const announceRouter=router;


### PR DESCRIPTION
#### Description
Any user admin or advertiser can see the announcement'details
#### Type of change
Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [ ] Unit
- [ ] Integration
- [X] End-to-end
#### How to Test
you can test using this route:
/api/v1/announcement/:id
#### Pivotal Tracker
[Finishes #170818342]