### PR TITLE
As a user I should be able to view my announcements

### DIFF
--- a/Server/src/controllers/announcementController.js
+++ b/Server/src/controllers/announcementController.js
@@ -181,6 +181,32 @@ const controller={
                 "data":result
             });  
         }
+    },
+    myAnnouncements(req,res){
+        const token={
+            id:req.tokenId,
+            email:req.tokenEmail,
+            is_admin:req.tokenIs_admin
+        }
+        const result=AnnouncementModel.myAnnouncements(token);
+        if(result=="not found"){
+            return res.status(403).json({
+                "status":"error",
+                "error":"you created no announcements"
+            });
+        }
+        else if(result=="not a user"){
+            return res.status(403).json({
+                "status":"error",
+                "error":"you are not a user"
+            });   
+        }
+        else{
+            return res.status(200).json({
+                "status":"success",
+                "data":result
+            });
+        }
     }
 
 }

--- a/Server/src/models/announcement.js
+++ b/Server/src/models/announcement.js
@@ -135,5 +135,19 @@ announcementDetails(id,token){
         return "not a user";
     }
 }
+myAnnouncements(token){
+    const user=users.find((us)=>us.id==token.id);
+    const myAnnouncement=announcements.find((announce)=>announce.owner==user.id);
+    if(user){
+        if(myAnnouncement){
+            return myAnnouncement;
+        }
+        else{
+            return "not found";
+        }
+    }else{
+        return "not a user";
+    }
+}
 }
 export default new Announcement();

--- a/Server/src/routes/announcementRoutes.js
+++ b/Server/src/routes/announcementRoutes.js
@@ -10,6 +10,7 @@ router.patch('/:id/sold',authenticate,validateInput(schemas.updateAnnounce),cont
 router.patch('/:id',authenticate,validateInput(schemas.updateAnnounce),controller.updateAnnouncement);
 router.delete('/:id',authenticate,controller.deleteAnnouncement);
 router.get('/announcements',authenticate,controller.viewAnnouncements);
+router.get('/myannouncements',authenticate,controller.myAnnouncements);
 router.get('/:id',authenticate,controller.announcementDetails);
 
 export const announceRouter=router;


### PR DESCRIPTION
#### Description
An advertiser can view all his announcements
#### Type of change
Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
- [ ] Unit
- [ ] Integration
- [X] End-to-end
#### How to Test
you can test through this route:
/api/v1/announcement/myannouncements
#### Pivotal Tracker
[Finishes #170820100]